### PR TITLE
Notify via Slack if link-check reports errors

### DIFF
--- a/.github/workflows/cron-linkcheck.yml
+++ b/.github/workflows/cron-linkcheck.yml
@@ -20,6 +20,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.0
         with:
           args: --verbose --no-progress api-example.yaml
+          fail: true
 
       - name: Report Status
         #if: steps.lychee.outputs.exit_code != 0
@@ -27,6 +28,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
+          notify_when: "failure"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/cron-linkcheck.yml
+++ b/.github/workflows/cron-linkcheck.yml
@@ -22,7 +22,8 @@ jobs:
           args: --verbose --no-progress api-example.yaml
 
       - name: Report Status
-        if: steps.lychee.outputs.exit_code != 0
+        #if: steps.lychee.outputs.exit_code != 0
+        if: always()
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}

--- a/.github/workflows/cron-linkcheck.yml
+++ b/.github/workflows/cron-linkcheck.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           status: ${{ job.status }}
           notify_when: "failure"
+          notification_title: "{workflow} has {status_message}"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/cron-linkcheck.yml
+++ b/.github/workflows/cron-linkcheck.yml
@@ -1,8 +1,13 @@
 name: Cron check links in OpenAPI spec
 
+#on:
+#  schedule:
+#    - cron: "0 0 * * 0" # Once a week on Sunday
+
 on:
-  schedule:
-    - cron: "0 0 * * 0" # Once a week on Sunday
+  push:
+    branches:
+      - test-slack-linkcheck
 
 jobs:
   linkChecker:
@@ -21,7 +26,6 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
-          notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 

--- a/.github/workflows/cron-linkcheck.yml
+++ b/.github/workflows/cron-linkcheck.yml
@@ -1,13 +1,8 @@
-name: Cron check links in OpenAPI spec
-
-#on:
-#  schedule:
-#    - cron: "0 0 * * 0" # Once a week on Sunday
+name: Check links in OpenAPI spec
 
 on:
-  push:
-    branches:
-      - test-slack-linkcheck
+  schedule:
+    - cron: "0 0 * * 0" # Once a week on Sunday
 
 jobs:
   linkChecker:


### PR DESCRIPTION
This PR:

- Notify via Slack if the link-check cron job reports errors